### PR TITLE
fix: address clippy warnings

### DIFF
--- a/crates/weave-cli/src/commands/bench.rs
+++ b/crates/weave-cli/src/commands/bench.rs
@@ -1152,7 +1152,7 @@ func HandleDelete(w http.ResponseWriter, r *http.Request) {
         total_git_clean as f64 / total_scenarios as f64 * 100.0,
     );
 
-    let improvement = total_weave_clean as i32 - total_git_clean as i32;
+    let improvement = total_weave_clean - total_git_clean;
     if improvement > 0 {
         println!(
             "\nweave resolved {} additional merge(s) that git could not.",

--- a/crates/weave-github/src/webhook.rs
+++ b/crates/weave-github/src/webhook.rs
@@ -79,8 +79,6 @@ pub struct PrEvent {
     pub pr_number: u64,
     pub head_sha: String,
     pub base_sha: String,
-    pub base_ref: String,
-    pub head_ref: String,
 }
 
 fn parse_pr_event(payload: &serde_json::Value) -> Option<PrEvent> {
@@ -90,8 +88,6 @@ fn parse_pr_event(payload: &serde_json::Value) -> Option<PrEvent> {
     let pr_number = pr["number"].as_u64()?;
     let head_sha = pr["head"]["sha"].as_str()?.to_string();
     let base_sha = pr["base"]["sha"].as_str()?.to_string();
-    let base_ref = pr["base"]["ref"].as_str()?.to_string();
-    let head_ref = pr["head"]["ref"].as_str()?.to_string();
 
     let (owner, repo) = repo_full_name.split_once('/')?;
     let owner = owner.to_string();
@@ -105,8 +101,6 @@ fn parse_pr_event(payload: &serde_json::Value) -> Option<PrEvent> {
         pr_number,
         head_sha,
         base_sha,
-        base_ref,
-        head_ref,
     })
 }
 


### PR DESCRIPTION
## Summary

Fix clippy warnings for unused code and unnecessary casts.

## Changes

- **Remove unused fields `base_ref` and `head_ref` from `PrEvent`**
  - These fields were parsed from webhook payload but never used in `handle_pull_request`
  - Resolves warning: `fields `base_ref` and `head_ref` are never read`

- **Remove unnecessary `i32` cast in `bench.rs`**
  - Variables `total_weave_clean` and `total_git_clean` are already `i32` type by default
  - Resolves warning: `casting to the same type is unnecessary (`i32` -> `i32`)`

## Testing

- `cargo check` passes
- `cargo clippy` no longer reports these warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)