### PR TITLE
[WIP] feat: add Scala language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,7 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.3.19"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d25bebaa97c9171af5766a5e5f23f6eac23e3ed9f4915193900dc4c50236f8"
 dependencies = [
  "git2",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags",
  "libc",
@@ -1335,9 +1335,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
@@ -2172,9 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f145e7245b12fc1cd20aa1777af45c9123c2108230d804d06cd01ff3ceac160a"
+version = "0.3.19"
 dependencies = [
  "git2",
  "rayon",
@@ -2189,18 +2187,23 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-embedded-template",
  "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-hcl",
+ "tree-sitter-htmlx-svelte",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-ocaml",
+ "tree-sitter-perl-next",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-xml",
@@ -2868,6 +2871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dart"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba6bf8675e6fe92ba6da371a5497ee5df2a04d2c503e3599c8ad771f6f1faec"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,6 +2931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-htmlx-svelte"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259693b6c5f6a7044de1a8142507aa1950406a4b124ffaab28c9050e30973dd"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-java"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +2978,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-ocaml"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d19db582b3855f56b5f9ec484170fbfb9ee60b938ec7720d76d2ee788e8b640"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-perl-next"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b02c571f4d63663ade506b1f81dd9f78e37a0014268c521b6e75df0603d911"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-php"
 version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3032,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83079f50ea7d03e0faf6be6260ed97538e6df7349ec3cbcbf5771f7b38e3c8b7"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
     "crates/weave-github",
 ]
 resolver = "2"
+
+[patch.crates-io]
+sem-core = { path = "../sem/crates/sem-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ members = [
     "crates/weave-github",
 ]
 resolver = "2"
-
-[patch.crates-io]
-sem-core = { path = "../sem/crates/sem-core" }

--- a/crates/weave-cli/Cargo.toml
+++ b/crates/weave-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 weave-core = { path = "../weave-core", version = "0.2.8" }
 weave-crdt = { path = "../weave-crdt", version = "0.2.8" }
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 diffy = "0.4"

--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -11,6 +11,7 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "*.f90", "*.f95", "*.f03", "*.f08",
     "*.xml", "*.plist", "*.svg", "*.csproj", "*.fsproj", "*.vbproj",
     "*.json", "*.yaml", "*.yml", "*.toml", "*.md",
+    "*.scala", "*.sc",
 ];
 
 pub fn run(driver_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -11,7 +11,7 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "*.f90", "*.f95", "*.f03", "*.f08",
     "*.xml", "*.plist", "*.svg", "*.csproj", "*.fsproj", "*.vbproj",
     "*.json", "*.yaml", "*.yml", "*.toml", "*.md",
-    "*.scala", "*.sc",
+    "*.scala", "*.sc", "*.sbt", "*.kojo", "*.mill",
 ];
 
 pub fn run(driver_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/weave-core/Cargo.toml
+++ b/crates/weave-core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools", "algorithms"]
 readme = "../../README.md"
 
 [dependencies]
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 diffy = "0.4"
 thiserror = "2"
 tempfile = "3"

--- a/crates/weave-core/tests/integration.rs
+++ b/crates/weave-core/tests/integration.rs
@@ -1738,6 +1738,125 @@ fn ts_function_conflict_narrowed_to_changed_lines() {
     );
 }
 
+// =============================================================================
+// Scala
+// =============================================================================
+
+#[test]
+fn scala_two_agents_add_different_methods() {
+    let base = r#"class UserService {
+  def findById(id: String): Option[User] = db.find(id)
+}
+"#;
+    let ours = r#"class UserService {
+  def findById(id: String): Option[User] = db.find(id)
+
+  def create(user: User): User = db.save(user)
+}
+"#;
+    let theirs = r#"class UserService {
+  def findById(id: String): Option[User] = db.find(id)
+
+  def delete(id: String): Unit = db.remove(id)
+}
+"#;
+
+    let result = entity_merge(base, ours, theirs, "UserService.scala");
+    assert!(
+        result.is_clean(),
+        "Two agents adding different methods should auto-resolve. Conflicts: {:?}",
+        result.conflicts
+    );
+    assert!(result.content.contains("create"));
+    assert!(result.content.contains("delete"));
+    assert!(result.content.contains("findById"));
+}
+
+#[test]
+fn scala_one_modifies_one_adds() {
+    // Top-level definitions (Scala 3 style) — one side modifies, other adds
+    let base = r#"package com.example
+
+def greet(name: String): String = s"Hello, $name"
+"#;
+    let ours = r#"package com.example
+
+def greet(name: String): String = s"Hello, $name!"
+"#;
+    let theirs = r#"package com.example
+
+def greet(name: String): String = s"Hello, $name"
+
+def farewell(name: String): String = s"Goodbye, $name"
+"#;
+
+    let result = entity_merge(base, ours, theirs, "greetings.scala");
+    assert!(
+        result.is_clean(),
+        "One modifying, one adding should auto-resolve. Conflicts: {:?}",
+        result.conflicts
+    );
+    assert!(result.content.contains("Hello, $name!"));
+    assert!(result.content.contains("farewell"));
+}
+
+#[test]
+fn scala_both_modify_same_method_incompatibly() {
+    // Top-level definition (Scala 3 style) — both modify incompatibly
+    let base = r#"package com.example
+
+def process(data: String): String = data.trim()
+"#;
+    let ours = r#"package com.example
+
+def process(data: String): String = data.trim().toUpperCase()
+"#;
+    let theirs = r#"package com.example
+
+def process(data: String): String = data.trim().toLowerCase()
+"#;
+
+    let result = entity_merge(base, ours, theirs, "processor.scala");
+    assert!(!result.is_clean());
+    assert_eq!(result.conflicts.len(), 1);
+    assert_eq!(result.conflicts[0].entity_name, "process");
+}
+
+#[test]
+fn scala_add_different_top_level_definitions() {
+    let base = r#"package com.example
+
+trait Repository[T] {
+  def findAll(): List[T]
+}
+"#;
+    let ours = r#"package com.example
+
+trait Repository[T] {
+  def findAll(): List[T]
+}
+
+case class User(id: String, name: String)
+"#;
+    let theirs = r#"package com.example
+
+trait Repository[T] {
+  def findAll(): List[T]
+}
+
+case class Product(id: String, price: Double)
+"#;
+
+    let result = entity_merge(base, ours, theirs, "models.scala");
+    assert!(
+        result.is_clean(),
+        "Adding different top-level case classes should auto-resolve. Conflicts: {:?}",
+        result.conflicts
+    );
+    assert!(result.content.contains("User"));
+    assert!(result.content.contains("Product"));
+}
+
 /// Check if a needle appears only inside conflict marker blocks
 fn is_inside_conflict_markers(content: &str, needle: &str) -> bool {
     let mut in_conflict = false;

--- a/crates/weave-crdt/Cargo.toml
+++ b/crates/weave-crdt/Cargo.toml
@@ -15,7 +15,7 @@ test-helpers = []
 
 [dependencies]
 automerge = "0.8"
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 weave-core = { path = "../weave-core", version = "0.2.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/weave-driver/Cargo.toml
+++ b/crates/weave-driver/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../../README.md"
 
 [dependencies]
 weave-core = { path = "../weave-core", version = "0.2.8" }
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 weave-crdt = { path = "../weave-crdt", version = "0.2.8", optional = true }
 serde_json = "1"
 env_logger = "0.11"

--- a/crates/weave-github/Cargo.toml
+++ b/crates/weave-github/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 weave-core = { version = "0.2.8", path = "../weave-core" }
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/weave-mcp/Cargo.toml
+++ b/crates/weave-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 weave-core = { path = "../weave-core", version = "0.2.8" }
 weave-crdt = { path = "../weave-crdt", version = "0.2.8" }
-sem-core = "0.3.12"
+sem-core = "0.3.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Enables entity-level semantic merging for Scala 2 and Scala 3 source files by wiring up the Scala support added in sem-core.

**Extensions supported** (per [github-linguist/linguist#7028](https://github.com/github-linguist/linguist/pull/7028)):
- `.scala` — standard Scala source files
- `.sc` — Scala scripts / Ammonite scripts
- `.sbt` — sbt build definitions
- `.mill` — Mill build scripts
- `.kojo` — Kojo learning environment

- Add *.scala, *.sc, *.sbt, *.mill, *.kojo to SUPPORTED_EXTENSIONS (setup.rs)
- Patch sem-core to v0.3.19 which includes tree-sitter-scala support
- Add 4 integration tests covering auto-resolve and conflict scenarios

This humble contribution has been sponsored by my employer @Chili-Piper

blocked on
* https://github.com/Ataraxy-Labs/sem/pull/80