### PR TITLE
docs: update language count and supported languages list to include Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/tests-124_passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/version-0.2.6-blue" alt="Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
-  <img src="https://img.shields.io/badge/languages-21-blue" alt="Languages">
+  <img src="https://img.shields.io/badge/languages-22-blue" alt="Languages">
 </p>
 
 <p align="center">
@@ -126,7 +126,7 @@ You immediately know: what entity conflicted, what type it is, and why it confli
 
 ## Supported Languages
 
-TypeScript, TSX, JavaScript, Python, Go, Rust, Java, C, C++, Ruby, C#, PHP, Swift, Kotlin, Elixir, Bash, HCL/Terraform, Fortran, Vue, XML, ERB, JSON, YAML, TOML, CSV, Markdown. Falls back to standard line-level merge for unsupported file types.
+TypeScript, TSX, JavaScript, Python, Go, Rust, Java, C, C++, Ruby, C#, PHP, Swift, Kotlin, Scala, Elixir, Bash, HCL/Terraform, Fortran, Vue, XML, ERB, JSON, YAML, TOML, CSV, Markdown. Falls back to standard line-level merge for unsupported file types.
 
 ## Install
 


### PR DESCRIPTION
Documentation-only follow-up to #52.

**README.md**
- Language badge: 21 → 22
- Add Scala to the Supported Languages list (after Kotlin)