### PR TITLE
Add Dart language support

### DIFF
--- a/crates/weave-cli/src/commands/bench_repo.rs
+++ b/crates/weave-cli/src/commands/bench_repo.rs
@@ -6,7 +6,7 @@ use weave_core::entity_merge_with_registry;
 use sem_core::parser::plugins::create_default_registry;
 
 const SUPPORTED_EXTENSIONS: &[&str] = &[
-    "ts", "tsx", "js", "jsx", "py", "rs", "go", "java", "c", "cpp", "cc", "h", "hpp", "rb", "cs",
+    "ts", "tsx", "js", "jsx", "py", "rs", "go", "java", "c", "cpp", "cc", "h", "hpp", "rb", "cs", "dart",
 ];
 
 struct Stats {

--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -12,6 +12,7 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "*.xml", "*.plist", "*.svg", "*.csproj", "*.fsproj", "*.vbproj",
     "*.json", "*.yaml", "*.yml", "*.toml", "*.md",
     "*.scala", "*.sc", "*.sbt", "*.kojo", "*.mill",
+    "*.dart",
 ];
 
 pub fn run(driver_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/weave-core/tests/integration.rs
+++ b/crates/weave-core/tests/integration.rs
@@ -1857,6 +1857,96 @@ case class Product(id: String, price: Double)
     assert!(result.content.contains("Product"));
 }
 
+// =============================================================================
+// Dart
+// =============================================================================
+
+#[test]
+fn dart_two_agents_add_different_functions() {
+    let base = r#"class Calculator {
+  int value = 0;
+}
+"#;
+    let ours = r#"class Calculator {
+  int value = 0;
+
+  void add(int amount) {
+    value += amount;
+  }
+}
+"#;
+    let theirs = r#"class Calculator {
+  int value = 0;
+
+  void subtract(int amount) {
+    value -= amount;
+  }
+}
+"#;
+
+    let result = entity_merge(base, ours, theirs, "calculator.dart");
+    assert!(
+        result.is_clean(),
+        "Two agents adding different functions to Dart class should auto-resolve. Conflicts: {:?}",
+        result.conflicts
+    );
+    assert!(result.content.contains("add(int amount)"));
+    assert!(result.content.contains("subtract(int amount)"));
+}
+
+#[test]
+fn dart_one_modifies_one_adds() {
+    let base = r#"void greet(String name) {
+  print('Hello, $name');
+}
+"#;
+    let ours = r#"void greet(String name) {
+  print('Greetings, $name!');
+}
+"#;
+    let theirs = r#"void greet(String name) {
+  print('Hello, $name');
+}
+
+void sayGoodbye(String name) {
+  print('Goodbye, $name');
+}
+"#;
+
+    let result = entity_merge(base, ours, theirs, "greetings.dart");
+    assert!(
+        result.is_clean(),
+        "One modifies existing function, other adds new function should auto-resolve. Conflicts: {:?}",
+        result.conflicts
+    );
+    assert!(result.content.contains("Greetings, $name!"));
+    assert!(result.content.contains("sayGoodbye"));
+}
+
+#[test]
+fn dart_both_modify_same_method_incompatibly() {
+    let base = r#"void process(String data) {
+  var d = data;
+  print(d);
+}
+"#;
+    let ours = r#"void process(String data) {
+  var d = data.toLowerCase();
+  print(d);
+}
+"#;
+    let theirs = r#"void process(String data) {
+  var d = data.toUpperCase();
+  print(d);
+}
+"#;
+
+    let result = entity_merge(base, ours, theirs, "processor.dart");
+    assert!(!result.is_clean(), "Incompatible changes to the same function must conflict");
+    assert!(is_inside_conflict_markers(&result.content, "toLowerCase()"));
+    assert!(is_inside_conflict_markers(&result.content, "toUpperCase()"));
+}
+
 /// Check if a needle appears only inside conflict marker blocks
 fn is_inside_conflict_markers(content: &str, needle: &str) -> bool {
     let mut in_conflict = false;

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -87,6 +87,24 @@
 
     <section style="border-top: none; padding-top: 12px;">
 
+      <!-- Dart language support -->
+      <div class="commit">
+        <div class="commit-header">
+          <span class="commit-date">May 10, 2026</span>
+        </div>
+        <div class="commit-title">Dart language support</div>
+        <div class="commit-tags">
+          <span class="commit-tag" style="background: #4ade8022; color: var(--green);">feature</span>
+        </div>
+        <div class="commit-body">
+          <p>Fully activates the semantic merge driver for Dart files.</p>
+          <ul>
+            <li>Registers the <code>.dart</code> extension in <code>weave setup</code> and repository benchmark tools.</li>
+            <li>Adds Dart-specific 3-way semantic merge integration tests to ensure clean auto-resolution of non-overlapping entity changes.</li>
+          </ul>
+        </div>
+      </div>
+
       <!-- v0.2.6 -->
       <div class="commit">
         <div class="commit-header">


### PR DESCRIPTION
Registers the `.dart` file extension in the `weave setup` and `bench_repo` commands.
The underlying `sem-core` dependency already extracts Dart entities, so this
fully enables the semantic merge driver for Dart files.

Includes 3-way semantic merge integration tests for Dart auto-resolution scenarios.
