### PR TITLE
docs: update language counts and benchmark scenarios for Dart and Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <img src="https://img.shields.io/badge/tests-124_passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/version-0.3.0-blue" alt="Version">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
-  <img src="https://img.shields.io/badge/languages-26-blue" alt="Languages">
+  <img src="https://img.shields.io/badge/languages-28-blue" alt="Languages">
 </p>
 
 <p align="center">

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -245,6 +245,7 @@
             <tr><td>TS: method reorder + modification</td><td class="win">clean</td><td class="win">clean</td><td class="win">clean</td></tr>
             <tr><td>Python: both add class methods</td><td class="win">clean</td><td class="win">clean</td><td class="lose">CONFLICT</td></tr>
             <tr><td>Rust: both add impl methods</td><td class="win">clean</td><td class="win">clean</td><td class="lose">CONFLICT</td></tr>
+            <tr><td>Dart: both add class methods</td><td class="win">clean</td><td class="win">clean</td><td class="lose">CONFLICT</td></tr>
             <tr><td>TS: enum modify + add variant</td><td class="win">clean</td><td class="win">clean</td><td class="win">clean</td></tr>
             <tr><td>TS: add JSDoc + modify body</td><td class="win">clean</td><td class="win">clean</td><td class="win">clean</td></tr>
             <tr><td>Rust: both add doc comments to different fns</td><td class="win">clean</td><td class="win">clean</td><td class="win">clean</td></tr>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -539,7 +539,7 @@
     <!-- Supported Languages -->
     <section id="languages">
       <h2>Supported languages</h2>
-      <p class="section-desc">Entity extraction powered by <a href="https://github.com/Ataraxy-Labs/sem" style="color:var(--green)">sem-core</a> and tree-sitter. 21 programming languages + 5 data formats.</p>
+      <p class="section-desc">Entity extraction powered by <a href="https://github.com/Ataraxy-Labs/sem" style="color:var(--green)">sem-core</a> and tree-sitter. 23 programming languages + 5 data formats.</p>
       <table>
         <thead>
           <tr><th>Language</th><th>Extensions</th><th>Entities</th></tr>
@@ -551,6 +551,8 @@
           <tr><td>Go</td><td>.go</td><td>functions, methods, types, vars, consts</td></tr>
           <tr><td>Rust</td><td>.rs</td><td>functions, structs, enums, impls, traits, mods, consts</td></tr>
           <tr><td>Java</td><td>.java</td><td>classes, methods, interfaces, enums, fields, constructors</td></tr>
+          <tr><td>Dart</td><td>.dart</td><td>classes, functions, methods, enums, extensions, mixins</td></tr>
+          <tr><td>Scala</td><td>.scala .sc .sbt</td><td>classes, objects, traits, functions, types</td></tr>
           <tr><td>C</td><td>.c .h</td><td>functions, structs, enums, unions, typedefs</td></tr>
           <tr><td>C++</td><td>.cpp .cc .hpp</td><td>functions, classes, structs, enums, namespaces, templates</td></tr>
           <tr><td>C#</td><td>.cs</td><td>classes, methods, interfaces, enums, structs, properties</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -208,7 +208,7 @@
 
     <!-- Languages -->
     <section class="fade-in">
-      <h2>26 languages</h2>
+      <h2>28 languages</h2>
       <p class="section-desc">Entity extraction powered by <a href="https://github.com/Ataraxy-Labs/sem" style="color:var(--green)">sem-core</a> and tree-sitter. Plus 5 data formats. <a href="docs.html#languages" style="color:var(--cyan)">Full list &rarr;</a></p>
 
       <div class="lang-chips">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -47,7 +47,7 @@ Full benchmark suite: 11ms. Individual merges: 65-374us.
 
 ## Key Features
 
-- 21 languages + 5 data formats (see full list below)
+- 23 languages + 5 data formats (see full list below)
 - Rename detection via confidence-scored structural hashing (0.95/0.8/0.6 scoring)
 - Commutative import merge with group preservation
 - Unordered class members (methods added at same position resolve cleanly)
@@ -100,7 +100,7 @@ claude mcp add --scope user weave -- weave-mcp
 
 ## Language Support
 
-21 programming languages:
+23 programming languages:
 
 | Language | Extensions | Entity Types |
 |----------|-----------|--------------|
@@ -110,6 +110,8 @@ claude mcp add --scope user weave -- weave-mcp
 | Go | .go | functions, methods, types, vars, consts |
 | Rust | .rs | functions, structs, enums, impls, traits, mods, consts |
 | Java | .java | classes, methods, interfaces, enums, fields, constructors |
+| Dart | .dart | classes, functions, methods, enums, extensions, mixins |
+| Scala | .scala .sc .sbt | classes, objects, traits, functions, types |
 | C | .c .h | functions, structs, enums, unions, typedefs |
 | C++ | .cpp .cc .hpp | functions, classes, structs, enums, namespaces, templates |
 | C# | .cs | classes, methods, interfaces, enums, structs, properties |


### PR DESCRIPTION
Reflects the recent addition of Dart and Scala support across all
documentation surfaces. Updates total language counts to 23 programming
languages (28 total including data formats).

- Update total counts in index.html, docs.html, llms.txt, and README.md
- Add Dart and Scala to the supported languages table in docs.html and llms.txt
- Include Dart class method auto-resolution in benchmarks.html
- Update README.md languages badge and supported list
