### PR TITLE
Add local setup mode for git attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,24 +163,10 @@ To revert back to normal git merging:
 weave unsetup
 ```
 
-To set up for just yourself (without modifying `.gitattributes`), use `.git/info/attributes` instead:
+To set up for just yourself (without modifying `.gitattributes`), write the same supported file type rules to `.git/info/attributes` instead:
 
 ```bash
-git config merge.weave.name "Entity-level semantic merge"
-git config merge.weave.driver "weave-driver %O %A %B %L %P"
-cat >> .git/info/attributes << 'EOF'
-*.ts merge=weave
-*.tsx merge=weave
-*.js merge=weave
-*.py merge=weave
-*.go merge=weave
-*.rs merge=weave
-*.java merge=weave
-*.c merge=weave
-*.cpp merge=weave
-*.rb merge=weave
-*.cs merge=weave
-EOF
+weave setup --local
 ```
 
 ## Jujutsu (jj)

--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use colored::Colorize;
@@ -12,7 +12,7 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "*.sc", "*.sbt", "*.kojo", "*.mill", "*.dart",
 ];
 
-pub fn run(driver_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(driver_path: Option<&str>, local: bool) -> Result<(), Box<dyn std::error::Error>> {
     // Verify we're in a git repo
     let git_dir = Path::new(".git");
     if !git_dir.exists() {
@@ -64,36 +64,36 @@ pub fn run(driver_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> 
         driver_cmd
     );
 
-    // Update .gitattributes
-    let gitattributes_path = Path::new(".gitattributes");
-    let mut existing = if gitattributes_path.exists() {
-        fs::read_to_string(gitattributes_path)?
+    // Update git attributes
+    let (attributes_label, attributes_path) = attributes_target(local)?;
+    if local {
+        if let Some(parent) = attributes_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let mut existing = if attributes_path.exists() {
+        fs::read_to_string(&attributes_path)?
     } else {
         String::new()
     };
 
-    let mut added = 0;
-    for ext in SUPPORTED_EXTENSIONS {
-        let pattern = format!("{} merge=weave", ext);
-        if !existing.contains(&pattern) {
-            if !existing.is_empty() && !existing.ends_with('\n') {
-                existing.push('\n');
-            }
-            existing.push_str(&pattern);
-            existing.push('\n');
-            added += 1;
-        }
-    }
+    let added = add_supported_patterns(&mut existing);
 
     if added > 0 {
-        fs::write(gitattributes_path, &existing)?;
+        fs::write(&attributes_path, &existing)?;
         println!(
-            "{} Updated .gitattributes ({} patterns added)",
+            "{} Updated {} ({} patterns added)",
             "✓".green().bold(),
+            attributes_label,
             added
         );
     } else {
-        println!("{} .gitattributes already configured", "✓".green().bold(),);
+        println!(
+            "{} {} already configured",
+            "✓".green().bold(),
+            attributes_label
+        );
     }
 
     println!(
@@ -120,32 +120,10 @@ pub fn unsetup() -> Result<(), Box<dyn std::error::Error>> {
         "✓".green().bold()
     );
 
-    // Remove weave patterns from .gitattributes
-    let gitattributes_path = Path::new(".gitattributes");
-    if gitattributes_path.exists() {
-        let content = fs::read_to_string(gitattributes_path)?;
-        let filtered: Vec<&str> = content
-            .lines()
-            .filter(|line| !line.contains("merge=weave"))
-            .collect();
-        let new_content = filtered.join("\n");
-        if filtered.is_empty() || new_content.trim().is_empty() {
-            fs::remove_file(gitattributes_path)?;
-            println!(
-                "{} Removed .gitattributes (was only weave patterns)",
-                "✓".green().bold()
-            );
-        } else {
-            let mut out = new_content;
-            if !out.ends_with('\n') {
-                out.push('\n');
-            }
-            fs::write(gitattributes_path, out)?;
-            println!(
-                "{} Cleaned weave patterns from .gitattributes",
-                "✓".green().bold()
-            );
-        }
+    // Remove weave patterns from tracked and local git attributes.
+    clean_attributes(Path::new(".gitattributes"), ".gitattributes")?;
+    if let Ok(local_attributes_path) = git_path("info/attributes") {
+        clean_attributes(&local_attributes_path, ".git/info/attributes")?;
     }
 
     println!(
@@ -154,6 +132,80 @@ pub fn unsetup() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+fn attributes_target(local: bool) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>> {
+    if local {
+        Ok((".git/info/attributes", git_path("info/attributes")?))
+    } else {
+        Ok((".gitattributes", PathBuf::from(".gitattributes")))
+    }
+}
+
+fn add_supported_patterns(existing: &mut String) -> usize {
+    let mut added = 0;
+    for ext in SUPPORTED_EXTENSIONS {
+        let pattern = format!("{} merge=weave", ext);
+        if !existing.contains(&pattern) {
+            if !existing.is_empty() && !existing.ends_with('\n') {
+                existing.push('\n');
+            }
+            existing.push_str(&pattern);
+            existing.push('\n');
+            added += 1;
+        }
+    }
+    added
+}
+
+fn clean_attributes(path: &Path, label: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)?;
+    let filtered: Vec<&str> = content
+        .lines()
+        .filter(|line| !line.contains("merge=weave"))
+        .collect();
+    let new_content = filtered.join("\n");
+    if filtered.is_empty() || new_content.trim().is_empty() {
+        fs::remove_file(path)?;
+        println!(
+            "{} Removed {} (was only weave patterns)",
+            "✓".green().bold(),
+            label
+        );
+    } else {
+        let mut out = new_content;
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        fs::write(path, out)?;
+        println!(
+            "{} Cleaned weave patterns from {}",
+            "✓".green().bold(),
+            label
+        );
+    }
+
+    Ok(())
+}
+
+fn git_path(requested_path: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-path", requested_path])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!("Failed to resolve git path '{}'", requested_path).into());
+    }
+
+    let path = String::from_utf8(output.stdout)?.trim().to_string();
+    if path.is_empty() {
+        return Err(format!("Git returned an empty path for '{}'", requested_path).into());
+    }
+
+    Ok(PathBuf::from(path))
 }
 
 fn which_driver() -> Result<String, Box<dyn std::error::Error>> {
@@ -178,4 +230,34 @@ fn which_driver() -> Result<String, Box<dyn std::error::Error>> {
     }
 
     Ok("weave-driver".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{add_supported_patterns, SUPPORTED_EXTENSIONS};
+
+    #[test]
+    fn add_supported_patterns_adds_all_supported_patterns() {
+        let mut existing = String::new();
+
+        let added = add_supported_patterns(&mut existing);
+
+        assert_eq!(added, SUPPORTED_EXTENSIONS.len());
+        for ext in SUPPORTED_EXTENSIONS {
+            assert!(existing.contains(&format!("{} merge=weave", ext)));
+        }
+    }
+
+    #[test]
+    fn add_supported_patterns_is_idempotent() {
+        let mut existing = String::from("*.ts merge=weave\n");
+
+        let first_added = add_supported_patterns(&mut existing);
+        let after_first = existing.clone();
+        let second_added = add_supported_patterns(&mut existing);
+
+        assert_eq!(first_added, SUPPORTED_EXTENSIONS.len() - 1);
+        assert_eq!(second_added, 0);
+        assert_eq!(existing, after_first);
+    }
 }

--- a/crates/weave-cli/src/main.rs
+++ b/crates/weave-cli/src/main.rs
@@ -16,6 +16,9 @@ enum Commands {
         /// Path to weave-driver binary (auto-detected if omitted)
         #[arg(long)]
         driver: Option<String>,
+        /// Write merge attributes to .git/info/attributes instead of .gitattributes
+        #[arg(long)]
+        local: bool,
     },
     /// Remove weave merge driver from the current Git repo
     Unsetup,
@@ -86,7 +89,7 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Commands::Setup { ref driver } => commands::setup::run(driver.as_deref()),
+        Commands::Setup { ref driver, local } => commands::setup::run(driver.as_deref(), local),
         Commands::Unsetup => commands::setup::unsetup(),
         Commands::Preview {
             ref branch,

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -57,8 +57,8 @@
 <span class="d"># Configure your repo</span>
 <span class="cmd">$ cd my-project</span>
 <span class="cmd">$ weave setup</span>
-<span class="g">&#10003;</span> Created .gitattributes with weave merge driver rules
-<span class="g">&#10003;</span> Configured git merge driver 'weave'
+<span class="g">&#10003;</span> Configured git merge driver
+<span class="g">&#10003;</span> Updated .gitattributes
 
 <span class="d"># Preview a merge before doing it</span>
 <span class="cmd">$ weave preview feature-branch</span>
@@ -465,6 +465,7 @@
         </div>
         <div class="cmd-doc-flags">
           <div class="flag"><code>--driver &lt;path&gt;</code> <span>Path to weave-driver binary (auto-detected if omitted)</span></div>
+          <div class="flag"><code>--local</code> <span>Write merge attributes to .git/info/attributes instead of .gitattributes</span></div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- add `weave setup --local` to write supported merge attribute patterns to `.git/info/attributes`
- reuse the same supported extension list as normal setup for local-only installs
- update `weave unsetup` to clean local weave attribute entries too
- replace the README's manual local setup snippet with `weave setup --local`

Fixes #89

## Test Plan

- `cargo fmt --check`
- `cargo test -p weave-cli`
- `cargo run -p weave-cli -- setup --help`
- verified in a throwaway git repo that `weave setup --local --driver true` writes `.git/info/attributes`, does not create `.gitattributes`, includes `*.dart merge=weave`, and `weave unsetup` removes the local attributes file
