### PR TITLE
Fix driver path breaking after brew upgrade

### DIFF
--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -209,22 +209,24 @@ fn git_path(requested_path: &str) -> Result<PathBuf, Box<dyn std::error::Error>>
 }
 
 fn which_driver() -> Result<String, Box<dyn std::error::Error>> {
-    // Check if weave-driver is next to current executable
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let candidate = dir.join("weave-driver");
-            if candidate.exists() {
-                return Ok(candidate.to_string_lossy().to_string());
-            }
-        }
-    }
-
-    // Check PATH
+    // Check PATH first — this returns the stable symlink path on package managers
+    // like Homebrew, avoiding breakage when the versioned Cellar path changes on
+    // upgrade (see https://github.com/Ataraxy-Labs/weave/issues/91).
     if let Ok(output) = Command::new("which").arg("weave-driver").output() {
         if output.status.success() {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !path.is_empty() {
                 return Ok(path);
+            }
+        }
+    }
+
+    // Fall back to checking next to current executable (e.g. local cargo build)
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("weave-driver");
+            if candidate.exists() {
+                return Ok(candidate.to_string_lossy().to_string());
             }
         }
     }


### PR DESCRIPTION
## Summary
- `which_driver()` checked `std::env::current_exe()` first, which resolves symlinks and returns the versioned Homebrew Cellar path (e.g. `/opt/homebrew/Cellar/weave/0.3.2/bin/weave-driver`)
- When `brew upgrade` installs a new version, the old Cellar path no longer exists, breaking weave
- Swapped priority: check PATH first (returns stable `/opt/homebrew/bin/weave-driver` symlink), fall back to `current_exe()` for local cargo builds

## Test plan
- [x] `cargo check -p weave-cli` passes
- [x] `cargo test -p weave-cli` passes (2/2 tests)
- [ ] Verify on a Homebrew install: `weave setup` should write `/opt/homebrew/bin/weave-driver` to git config instead of the Cellar path

Fixes #91