### PR TITLE
Add cargo-binstall support

### DIFF
--- a/crates/weave-cli/Cargo.toml
+++ b/crates/weave-cli/Cargo.toml
@@ -25,6 +25,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [features]
 default = []
 vendored-openssl = ["openssl"]

--- a/crates/weave-driver/Cargo.toml
+++ b/crates/weave-driver/Cargo.toml
@@ -18,5 +18,13 @@ serde_json = "1"
 env_logger = "0.11"
 log = "0.4"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [features]
 crdt = ["weave-crdt"]

--- a/crates/weave-mcp/Cargo.toml
+++ b/crates/weave-mcp/Cargo.toml
@@ -27,6 +27,14 @@ schemars = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [features]
 default = []
 vendored-openssl = ["openssl"]


### PR DESCRIPTION
## Summary

- Add `[package.metadata.binstall]` to weave-cli, weave-driver, and weave-mcp
- Maps to existing release asset naming (`{name}-{target}.tar.gz`, `.zip` for Windows)
- Enables `cargo binstall weave-cli`, `cargo binstall weave-driver`, `cargo binstall weave-mcp`

Closes #104