### PR TITLE
Preserve semantic conflicts when git merges cleanly

### DIFF
--- a/crates/weave-core/src/merge.rs
+++ b/crates/weave-core/src/merge.rs
@@ -679,9 +679,8 @@ pub fn entity_merge_with_registry(
         audit,
     };
 
-    // Floor: never produce more conflict markers than git merge-file.
-    // Entity merge can split one git conflict into multiple per-entity conflicts,
-    // or interstitial merges can produce conflicts not tracked in the conflicts vec.
+    // Floor: when both entity merge and git conflict, prefer the smaller marker set.
+    // Do not let git's clean-but-duplicate output erase a semantic conflict.
     let entity_markers = entity_result
         .content
         .lines()
@@ -694,7 +693,7 @@ pub fn entity_merge_with_registry(
             .lines()
             .filter(|l| l.starts_with("<<<<<<<"))
             .count();
-        if entity_markers > git_markers {
+        if git_markers > 0 && entity_markers > git_markers {
             return git_result;
         }
     }

--- a/crates/weave-core/tests/integration.rs
+++ b/crates/weave-core/tests/integration.rs
@@ -1,4 +1,4 @@
-use weave_core::entity_merge;
+use weave_core::{conflict::ConflictKind, entity_merge};
 
 // =============================================================================
 // Core value prop: independent entity changes auto-resolve
@@ -97,6 +97,33 @@ fn ts_both_modify_same_function_incompatibly() {
     assert_eq!(result.conflicts.len(), 1);
     assert_eq!(result.conflicts[0].entity_name, "process");
     // Should have enhanced conflict markers
+    assert!(result.content.contains("<<<<<<< ours"));
+    assert!(result.content.contains(">>>>>>> theirs"));
+}
+
+#[test]
+fn ts_same_named_function_added_at_different_positions_conflicts() {
+    let base = r#"function first() { return 1; }
+function second() { return 2; }
+"#;
+    let ours = r#"function first() { return 1; }
+function computeKey(input) { return input.id; }
+function second() { return 2; }
+"#;
+    let theirs = r#"function first() { return 1; }
+function second() { return 2; }
+function computeKey(input) { return `${input.kind}:${input.id}`; }
+"#;
+
+    let result = entity_merge(base, ours, theirs, "sample.ts");
+    assert!(
+        !result.is_clean(),
+        "same named additions with different bodies must conflict, not duplicate cleanly. Content:\n{}",
+        result.content
+    );
+    assert_eq!(result.conflicts.len(), 1);
+    assert_eq!(result.conflicts[0].entity_name, "computeKey");
+    assert_eq!(result.conflicts[0].kind, ConflictKind::BothAdded);
     assert!(result.content.contains("<<<<<<< ours"));
     assert!(result.content.contains(">>>>>>> theirs"));
 }


### PR DESCRIPTION
## Summary

Fixes #107 by preserving entity-level semantic conflicts when Git's line merge reports a clean result that would duplicate same-named divergent additions.

`weave` already resolved the issue case as a `BothAdded` semantic conflict, but the later marker-count floor replaced that conflict with `git merge-file` output whenever Git had fewer markers. In the issue repro, Git has zero markers because it silently emits both `computeKey` definitions, so the semantic conflict was erased.

This PR keeps the marker-count floor only when Git also reports conflict markers. Git-clean output can no longer mask an entity-level semantic conflict.

cc @rs545837

## Validation

- Direct `weave-driver` issue repro now exits `1` and reports `function computeKey: both added`.
- `cargo fmt --check`
- `cargo test -p weave-core`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
