### PR TITLE
feat(setup): weave setup --global (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ To set up for just yourself (without modifying `.gitattributes`), write the same
 weave setup --local
 ```
 
+### Global (every repo)
+
+To make weave the default merge driver for **all** your repos at once (no per-repo setup, like [mergiraf](https://mergiraf.org/usage.html#registration-as-a-git-merge-driver)):
+
+```bash
+weave setup --global
+```
+
+This writes the driver to your `~/.gitconfig` and the supported file-type rules to git's global attributes file (`~/.config/git/attributes`, or your `core.attributesfile` if set). No git repo required. Make sure `weave-driver` is on your `PATH` (it ships next to the `weave` binary).
+
+The equivalent manual config, if you prefer:
+
+```bash
+git config --global merge.weave.name "Entity-level semantic merge"
+git config --global merge.weave.driver "weave-driver %O %A %B %L %P"
+# then add `*.ts merge=weave` (etc.) to ~/.config/git/attributes
+```
+
 ## Jujutsu (jj)
 
 Add to your jj config (`jj config edit --user`):

--- a/crates/weave-cli/src/commands/setup.rs
+++ b/crates/weave-cli/src/commands/setup.rs
@@ -12,11 +12,18 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "*.sc", "*.sbt", "*.kojo", "*.mill", "*.dart",
 ];
 
-pub fn run(driver_path: Option<&str>, local: bool) -> Result<(), Box<dyn std::error::Error>> {
-    // Verify we're in a git repo
-    let git_dir = Path::new(".git");
-    if !git_dir.exists() {
-        return Err("Not in a git repository. Run `weave setup` from the repo root.".into());
+pub fn run(
+    driver_path: Option<&str>,
+    local: bool,
+    global: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Global setup configures git itself, so it doesn't need to run inside a
+    // repo. Per-repo setup does.
+    if !global {
+        let git_dir = Path::new(".git");
+        if !git_dir.exists() {
+            return Err("Not in a git repository. Run `weave setup` from the repo root, or `weave setup --global` to configure git for every repo.".into());
+        }
     }
 
     // Resolve driver binary path
@@ -42,31 +49,34 @@ pub fn run(driver_path: Option<&str>, local: bool) -> Result<(), Box<dyn std::er
         );
     }
 
-    // Configure git merge driver
+    // Configure git merge driver (in ~/.gitconfig when --global).
     let driver_cmd = format!("{} %O %A %B %L %P", driver);
-    let status = Command::new("git")
-        .args(["config", "merge.weave.name", "Entity-level semantic merge"])
-        .status()?;
-    if !status.success() {
+    let git_config = |args: &[&str]| -> std::io::Result<std::process::ExitStatus> {
+        let mut full = vec!["config"];
+        if global {
+            full.push("--global");
+        }
+        full.extend_from_slice(args);
+        Command::new("git").args(&full).status()
+    };
+
+    if !git_config(&["merge.weave.name", "Entity-level semantic merge"])?.success() {
         return Err("Failed to set merge.weave.name".into());
     }
-
-    let status = Command::new("git")
-        .args(["config", "merge.weave.driver", &driver_cmd])
-        .status()?;
-    if !status.success() {
+    if !git_config(&["merge.weave.driver", &driver_cmd])?.success() {
         return Err("Failed to set merge.weave.driver".into());
     }
 
     println!(
-        "{} Configured git merge driver: {}",
+        "{} Configured git merge driver{}: {}",
         "✓".green().bold(),
+        if global { " (global)" } else { "" },
         driver_cmd
     );
 
     // Update git attributes
-    let (attributes_label, attributes_path) = attributes_target(local)?;
-    if local {
+    let (attributes_label, attributes_path) = attributes_target(local, global)?;
+    if local || global {
         if let Some(parent) = attributes_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -134,12 +144,49 @@ pub fn unsetup() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn attributes_target(local: bool) -> Result<(&'static str, PathBuf), Box<dyn std::error::Error>> {
-    if local {
-        Ok((".git/info/attributes", git_path("info/attributes")?))
+fn attributes_target(
+    local: bool,
+    global: bool,
+) -> Result<(String, PathBuf), Box<dyn std::error::Error>> {
+    if global {
+        let path = global_attributes_path()?;
+        Ok((path.display().to_string(), path))
+    } else if local {
+        Ok((
+            ".git/info/attributes".to_string(),
+            git_path("info/attributes")?,
+        ))
     } else {
-        Ok((".gitattributes", PathBuf::from(".gitattributes")))
+        Ok((".gitattributes".to_string(), PathBuf::from(".gitattributes")))
     }
+}
+
+/// The file git reads global attributes from. Respects an existing
+/// `core.attributesfile`; otherwise git's default `~/.config/git/attributes`
+/// (which git reads automatically with no extra config).
+fn global_attributes_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Ok(out) = Command::new("git")
+        .args(["config", "--global", "core.attributesfile"])
+        .output()
+    {
+        if out.status.success() {
+            let configured = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !configured.is_empty() {
+                let expanded = if let Some(rest) = configured.strip_prefix("~/") {
+                    let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"))?;
+                    PathBuf::from(home).join(rest)
+                } else {
+                    PathBuf::from(configured)
+                };
+                return Ok(expanded);
+            }
+        }
+    }
+    let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"))?;
+    Ok(PathBuf::from(home)
+        .join(".config")
+        .join("git")
+        .join("attributes"))
 }
 
 fn add_supported_patterns(existing: &mut String) -> usize {

--- a/crates/weave-cli/src/main.rs
+++ b/crates/weave-cli/src/main.rs
@@ -11,7 +11,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Configure the current Git repo to use weave as merge driver
+    /// Configure Git to use weave as merge driver (this repo, or --global for all repos)
     Setup {
         /// Path to weave-driver binary (auto-detected if omitted)
         #[arg(long)]
@@ -19,6 +19,10 @@ enum Commands {
         /// Write merge attributes to .git/info/attributes instead of .gitattributes
         #[arg(long)]
         local: bool,
+        /// Configure git globally (~/.gitconfig + global attributes) so weave is
+        /// the default driver in every repo. No git repo required.
+        #[arg(long)]
+        global: bool,
     },
     /// Remove weave merge driver from the current Git repo
     Unsetup,
@@ -89,7 +93,11 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Commands::Setup { ref driver, local } => commands::setup::run(driver.as_deref(), local),
+        Commands::Setup {
+            ref driver,
+            local,
+            global,
+        } => commands::setup::run(driver.as_deref(), local, global),
         Commands::Unsetup => commands::setup::unsetup(),
         Commands::Preview {
             ref branch,


### PR DESCRIPTION
Closes #110.

Adds a `weave setup --global` flag that configures git in `~/.gitconfig` and writes the supported file-type rules to git's global attributes file (`~/.config/git/attributes`, or `core.attributesfile` if set), so weave becomes the default merge driver in every repo with no per-repo setup — the mergiraf-style flow @mikkelam asked for. No git repo required to run it. Documented in the README.

(#107 and #24 are covered by @edouard-andrei's #112 and #113.)