### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,4 +329,4 @@ Uses [sem-core](https://github.com/Ataraxy-Labs/sem) for entity extraction via t
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Ataraxy-Labs/weave&type=Date)](https://star-history.com/#Ataraxy-Labs/weave&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Ataraxy-Labs/weave&type=Date)](https://star-history.dera.page/#Ataraxy-Labs/weave&Date)


### PR DESCRIPTION
The star history chart in the README was broken because the underlying service was discontinued. Point it at a working instance so the chart renders again.