### PR TITLE
fix(render): stop dropping file_only text when other entities survive

### DIFF
--- a/crates/weave-core/src/v2/mod.rs
+++ b/crates/weave-core/src/v2/mod.rs
@@ -256,6 +256,46 @@ mod tests {
             );
         }
     }
+
+    /// Reproduces #148: a side that deletes every entity in the file
+    /// collapses, in `extract_regions`, to a single `file_only` region
+    /// instead of the `file_header`/`file_footer` keys the other two sides
+    /// keep for the very same trailing text. `merge_interstitials` 3-way
+    /// merges by key, so on that side `file_footer` simply is not present
+    /// and reads back as `""`; since base and theirs still agree on
+    /// `file_footer`, the ladder's second rung (`base == theirs -> take
+    /// ours`) picks that empty string, discarding text every one of the
+    /// three inputs agreed on.
+    ///
+    /// A single-entity repro would not show this: `render` has a *separate*,
+    /// correct fallback that emits `file_only` verbatim when the whole
+    /// merge produces zero surviving items, which papers over the bug. This
+    /// case keeps `bar` alive as a genuine modify/delete conflict so `items`
+    /// is non-empty and that fallback cannot fire.
+    #[test]
+    fn shared_top_level_text_survives_when_one_side_deletes_every_entity() {
+        let base = "def foo():\n    return 1\n\n\ndef bar():\n    return 1\n\n\nshared = 5\n";
+        let ours = "shared = 5\n";
+        let theirs = "def foo():\n    return 1\n\n\ndef bar():\n    return 2\n\n\nshared = 5\n";
+
+        let result = merge_file(
+            base,
+            ours,
+            theirs,
+            "m.py",
+            &crate::merge::PARSER_REGISTRY,
+            &MarkerFormat::default(),
+            &Host::default(),
+        )
+        .expect("theirs still has entities; this must not fall back to Unsupported");
+
+        assert!(
+            result.content.contains("shared = 5"),
+            "top-level statement unanimous across base/ours/theirs must survive \
+             the merge, got: {:?}",
+            result.content,
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/weave-core/src/v2/render.rs
+++ b/crates/weave-core/src/v2/render.rs
@@ -340,17 +340,35 @@ pub(crate) fn render(
         first = false;
     }
 
-    // Gaps nothing surviving leads, then the footer. Both are text some version
-    // wrote; neither is this merge's to discard — and both sit at the same
-    // boundary, the end of the file, so they go through the same join: a blank
-    // run rolled forward past the last surviving declaration and a blank footer
-    // state one distance between that declaration and the end, not two.
+    // Gaps nothing surviving leads, then the footer, then `file_only`. All
+    // three are text some version wrote; none is this merge's to discard —
+    // and all three sit at the same boundary, the end of the file, so they
+    // go through the same join: a blank run rolled forward past the last
+    // surviving declaration and a blank footer state one distance between
+    // that declaration and the end, not two.
+    //
+    // `file_only` is a side's WHOLE file, in one region, keyed distinctly
+    // from `file_header`/`file_footer` — `extract_regions` takes that path
+    // exactly when a side has zero entities (see its module docs). A side
+    // in that shape has no `file_footer` key at all, so `merge_interstitials`
+    // reads it back as `""` there; when the other two sides agree on
+    // `file_footer`, the ladder's `base == theirs -> take ours` rung then
+    // picks that absent side's `""`, discarding text every version agreed
+    // on (#148). Gating this key's own, correctly-merged text on
+    // `items.is_empty()` (previously: only surface it when the WHOLE
+    // document merged to zero entities) meant it recovered that loss in
+    // exactly the one case where nothing else in the file needed it, and
+    // dropped it in every other. It is never claimed by the entity-following
+    // mechanism above — `Interstitials::new` pre-excludes it from
+    // `lead_by_entity`/`trailing` because no entity survives on the side
+    // that produced it — so folding it into this join is always safe.
     let tail: Vec<&str> = interstitials
         .trailing
         .iter()
         .filter(|key| spent.insert(key.as_str()))
         .filter_map(|key| interstitials.merged.get(key.as_str()).map(String::as_str))
         .chain(interstitials.merged.get("file_footer").map(String::as_str))
+        .chain(interstitials.merged.get("file_only").map(String::as_str))
         .collect();
     let joined = join_gaps(tail);
     if !joined.is_empty() {
@@ -358,11 +376,6 @@ pub(crate) fn render(
             out.push('\n');
         }
         out.push_str(&joined);
-    }
-    if let Some(only) = interstitials.merged.get("file_only") {
-        if items.is_empty() {
-            out.push_str(only);
-        }
     }
     out
 }


### PR DESCRIPTION
Fixes #148.

## The bug

`extract_regions()` collapses a side to a single `file_only` region only when that side has **zero entities in the whole file**. The other sides key the very same trailing text as `file_header`/`between:.../file_footer` instead — different keys, same bytes.

`merge_interstitials()` 3-way-merges these per-side `HashMap<key, text>`s by key. On the zero-entity side, `file_footer` simply isn't present, and reads back as `""`. When the other two sides *agree* on `file_footer` (i.e. base == theirs there), the ladder's `base == theirs -> take ours` rung picks that absent side's `""`, silently discarding text every version actually agreed on. Exit 0, no warning — matches the issue title exactly.

`render()` already computed the *correct* merged `file_only` text, but only surfaced it when `items.is_empty()` — i.e. only when the **whole document** merged to zero surviving entities, not just this one key. That recovered the loss in exactly the one case where nothing else in the file needed the key (which is why the original two-file, zero-entity-on-every-side repro no longer reaches this code path at all on current `main` — it's now caught earlier by the `Unsupported::NoEntities` guard in `merge_file()` and falls back to the line-level path). It dropped the text everywhere else, including the ordinary case this PR reproduces: one side deletes some entities while a *different* entity elsewhere in the same file still conflicts and survives, so `items` is non-empty.

## The fix

Fold `file_only` into the same trailing join as `file_footer`/orphaned gaps instead of gating it separately behind `items.is_empty()`. It's already excluded from the entity-following mechanism in `Interstitials::new` (nothing can "lead" it — no entity survives on the side that produced it), so no entity's leading gap can ever claim it twice; joining it here is always safe.

## Testing

- Added `v2::tests::shared_top_level_text_survives_when_one_side_deletes_every_entity`, which reproduces the drop on current `main` (confirmed failing before this change, with the shared statement completely absent from the merged output) and passes after it.
- `cargo test -p weave-core --lib` — 202/202 pass.
- `cargo test -p weave-core --tests` (integration + `laws_merge` property suite + `public_properties` + `setup_extension_coverage`) — all green, including `l4_no_silent_loss` and `control_loss_checker_detects_a_dropped_sentinel`.
- `cargo clippy -p weave-core --lib --all-targets -- -D warnings` — clean.
- `cargo fmt -p weave-core --check` — clean.

## Note on scope

I found an unmerged `fix/issue-148` branch already on this repo (diverged 2026-08-22, last commit 2026-08-26) that attempted a fix along similar lines before the `v2/` render/match_phase refactor moved past it. I didn't build on that branch — it predates the current `v2::render` module shape by enough that porting it forward would have meant re-deriving most of it anyway — but wanted to flag it exists in case there's context there I'm missing, or in case you'd rather fold this into whatever that branch was working toward.

I read the issue body only for the bug description; the fix and test above were written against the current `main` source, read directly.
